### PR TITLE
fix: send watch-party invitations through Resend

### DIFF
--- a/components/account/WatchPartyFriendInviteDialog.tsx
+++ b/components/account/WatchPartyFriendInviteDialog.tsx
@@ -14,15 +14,16 @@ import { cn } from '@/lib/utils'
 function resultNotice(friendName: string, result: WatchPartyInviteResult) {
   if (result.emailStatus === 'sent') return { tone: 'success' as const, text: `Đã gửi thông báo trên web và email cho ${friendName}.` }
   if (result.emailStatus === 'failed') {
-    const detail = result.emailReason === 'firebase_admin' ? 'Firebase Admin chưa sẵn sàng' : 'Gmail SMTP chưa gửi được'
+    const detail = result.emailReason === 'firebase_admin' ? 'Firebase Admin chưa sẵn sàng' : 'dịch vụ email chưa gửi được'
     return { tone: 'warning' as const, text: `Thông báo trên web đã gửi; email chưa gửi (${detail}).` }
   }
   const details: Record<NonNullable<WatchPartyInviteResult['emailReason']>, string> = {
-    not_configured: 'SMTP chưa được cấu hình trên Render',
+    not_configured: 'dịch vụ email chưa được cấu hình trên Render',
     disabled: 'người nhận đã tắt thông báo email',
     no_email: 'tài khoản người nhận không có email',
     unverified: 'email người nhận chưa được xác minh',
     firebase_admin: 'Firebase Admin chưa sẵn sàng',
+    email_api_error: 'dịch vụ email chưa gửi được',
     smtp_error: 'Gmail SMTP chưa gửi được',
   }
   return { tone: 'warning' as const, text: `Thông báo trên web đã gửi; không gửi email vì ${result.emailReason ? details[result.emailReason] : 'email không khả dụng'}.` }

--- a/docs/social-chat-email-setup.md
+++ b/docs/social-chat-email-setup.md
@@ -7,7 +7,7 @@
 3. Thêm `localhost`, domain Vercel và domain production vào **Authorized domains**.
 4. Deploy `firebase-database.rules.json` bằng `firebase deploy --only database` sau khi kiểm thử.
 
-Firebase Authentication tiếp tục tự gửi email xác minh và reset mật khẩu. Gmail SMTP chỉ gửi lời mời xem chung.
+Firebase Authentication tiếp tục tự gửi email xác minh và reset mật khẩu. Resend (hoặc SMTP fallback) chỉ gửi lời mời xem chung.
 
 ## Render backend
 
@@ -21,6 +21,17 @@ FIREBASE_DATABASE_URL=https://moviewiser-watch-party-77fb3-default-rtdb.asia-sou
 
 Không gửi service-account JSON hoặc App Password qua chat, không commit vào Git. Nếu không dùng Secret File, backend cũng hỗ trợ `FIREBASE_SERVICE_ACCOUNT_JSON`, `FIREBASE_SERVICE_ACCOUNT_BASE64`, hoặc ba biến tách rời `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`.
 
+### Gửi email bằng Resend
+
+Render Free nên dùng Resend HTTPS API thay cho SMTP. Sau khi verify domain trên Resend, đặt hai biến bắt buộc trên Render:
+
+```env
+RESEND_API_KEY=<resend-api-key>
+RESEND_FROM=CineMind <invite@namtechie.id.vn>
+```
+
+`RESEND_REPLY_TO=support@namtechie.id.vn` là tùy chọn. Không thêm biến này vẫn gửi được; chỉ thêm khi địa chỉ support thực sự nhận thư. Server ưu tiên Resend nếu có đủ hai biến trên, còn nhóm `MAIL_*` chỉ làm fallback. Không đặt bất kỳ biến Resend nào ở Vercel hoặc dưới tiền tố `NEXT_PUBLIC_*`.
+
 ## Xử lý lỗi 404 và permission denied
 
 - Nếu `POST /api/friends/lookup-email` trả `404`, frontend đã trỏ đúng service nhưng Render đang chạy phiên bản cũ chưa có route này. Deploy lại thư mục `socket-server`, sau đó kiểm tra `/ready` trước khi thử lại.
@@ -28,12 +39,12 @@ Không gửi service-account JSON hoặc App Password qua chat, không commit v�
 - Nếu console báo `presenceConnections` hoặc `presenceLastSeen: permission_denied`, deploy file `firebase-database.rules.json` lên đúng project `moviewiser-watch-party-77fb3`. Sửa rules trong Git nhưng chưa deploy sẽ không thay đổi quyền của Realtime Database production.
 - `NEXT_PUBLIC_WATCH_PARTY_API_URL` trên Vercel/local hiện vẫn dùng URL gốc của service (ví dụ `https://moviewiser-socket.onrender.com`); không cần thêm URL riêng cho endpoint tìm email.
 
-Thiết lập các biến `FIREBASE_DATABASE_URL`, `APP_BASE_URL` và nhóm `MAIL_*` được liệt kê trong `socket-server/README.md`. Tài khoản Gmail gửi mail phải bật 2-Step Verification và dùng App Password 16 ký tự.
+Thiết lập các biến `FIREBASE_DATABASE_URL`, `APP_BASE_URL`, `RESEND_*` và SMTP fallback được liệt kê trong `socket-server/README.md`.
 
 Kiểm tra sau deploy:
 
-1. `GET /ready` trả bốn trạng thái Firebase là `true`. `mailConfigured`/`mailHealthy` có thể là `false` mà lookup email và notification web vẫn hoạt động.
+1. `GET /ready` trả bốn trạng thái Firebase là `true`, cùng `mailProvider: "resend"`, `mailConfigured: true` và `mailHealthy: true`.
 2. Đăng nhập production bằng Google và xác nhận profile được tạo.
 3. Tìm email đúng/sai; request thứ 11 trong một phút phải bị giới hạn.
-4. Gửi lời mời từ một thành viên phòng đã đăng nhập; người nhận thấy notification có link vào phòng. API báo email `sent`, hoặc báo lý do `not_configured`, `disabled`, `no_email`, `unverified`, `firebase_admin`, `smtp_error` mà không làm mất notification web.
+4. Gửi lời mời từ một thành viên phòng đã đăng nhập; người nhận thấy notification có link vào phòng. API báo email `sent`, hoặc báo lý do `not_configured`, `disabled`, `no_email`, `unverified`, `firebase_admin`, `email_api_error`, `smtp_error` mà không làm mất notification web.
 5. Tắt **Email mời xem chung** trong Quyền riêng tư; lần mời sau chỉ xuất hiện trong ứng dụng.

--- a/lib/account-types.ts
+++ b/lib/account-types.ts
@@ -140,7 +140,7 @@ export interface WatchPartyInviteResult {
   inviteId: string
   inAppStatus: 'sent'
   emailStatus: 'sent' | 'skipped' | 'failed'
-  emailReason?: 'not_configured' | 'disabled' | 'no_email' | 'unverified' | 'firebase_admin' | 'smtp_error'
+  emailReason?: 'not_configured' | 'disabled' | 'no_email' | 'unverified' | 'firebase_admin' | 'email_api_error' | 'smtp_error'
 }
 
 export const DEFAULT_PRIVACY: AccountPrivacy = {

--- a/lib/social-api.ts
+++ b/lib/social-api.ts
@@ -13,14 +13,22 @@ async function request<T>(path: string, token: string, body: unknown): Promise<T
   const baseUrl = serviceUrl()
   if (!baseUrl) throw new SocialApiError('Dịch vụ cộng đồng chưa được cấu hình.', 0, 'SERVICE_NOT_CONFIGURED')
   let response: Response
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), 20_000)
   try {
     response = await fetch(`${baseUrl}${path}`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
+      signal: controller.signal,
     })
-  } catch {
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new SocialApiError('Dịch vụ phản hồi quá lâu. Hãy thử lại.', 0, 'TIMEOUT')
+    }
     throw new SocialApiError('Không kết nối được dịch vụ cộng đồng. Hãy kiểm tra watch-party server.', 0, 'NETWORK_ERROR')
+  } finally {
+    window.clearTimeout(timeout)
   }
   const payload = await response.json().catch(() => ({}))
   if (!response.ok) {

--- a/socket-server/README.md
+++ b/socket-server/README.md
@@ -33,6 +33,10 @@ FIREBASE_PROJECT_ID=moviewiser-watch-party-77fb3
 FIREBASE_DATABASE_URL=https://moviewiser-watch-party-77fb3-default-rtdb.asia-southeast1.firebasedatabase.app
 GOOGLE_APPLICATION_CREDENTIALS=/etc/secrets/firebase-service-account.json
 APP_BASE_URL=https://your-vercel-domain.vercel.app
+RESEND_API_KEY=<server-only-resend-api-key>
+RESEND_FROM=CineMind <invite@your-domain.example>
+# Optional; omit when the mailbox does not exist
+RESEND_REPLY_TO=support@your-domain.example
 MAIL_HOST=smtp.gmail.com
 MAIL_PORT=587
 MAIL_SECURE=false
@@ -49,15 +53,21 @@ LIVEKIT_API_KEY=<server-only-api-key>
 LIVEKIT_API_SECRET=<server-only-api-secret>
 ```
 
+### Email trên Render Free
+
+Resend qua HTTPS là cấu hình được ưu tiên. Chỉ cần `RESEND_API_KEY` và `RESEND_FROM`; `RESEND_REPLY_TO` hoàn toàn tùy chọn và sẽ không được gửi trong request nếu bỏ trống. Domain trong `RESEND_FROM` phải ở trạng thái verified trên Resend. Ví dụ hợp lệ: `CineMind <invite@namtechie.id.vn>`.
+
+Nhóm `MAIL_*` chỉ là SMTP fallback cho local hoặc hạ tầng cho phép kết nối SMTP. Khi cả Resend và SMTP cùng được cấu hình, server luôn chọn Resend. Tất cả key và mật khẩu mail là server-only: chỉ đặt trên Render, không đưa sang Vercel, Git hoặc biến `NEXT_PUBLIC_*`.
+
 `CLIENT_ORIGINS` nhận nhiều origin phân cách bằng dấu phẩy. Server luôn cho phép loopback `localhost`, `127.0.0.1` và `::1` để frontend local gọi Render trong lúc phát triển.
 
 `MEDIA_ALLOWED_HOSTS` nhận hostname CDN bổ sung, phân cách bằng dấu phẩy; có thể dùng dạng `*.example.com`. Các host KKPhim và `s3.phim1280.tv` đã có trong allowlist mặc định. Cùng một chính sách được áp dụng cho probe, tạo phòng, proxy và từng bước redirect.
 
 Firebase Admin không cần nâng Firebase lên Blaze. Cách ít lỗi nhất trên Render là tạo **Secret File** tên `firebase-service-account.json`, dán nguyên JSON tải từ Firebase Console → Project settings → Service accounts, rồi đặt `GOOGLE_APPLICATION_CREDENTIALS=/etc/secrets/firebase-service-account.json`. Có thể dùng một trong ba phương án thay thế: `FIREBASE_SERVICE_ACCOUNT_JSON`, `FIREBASE_SERVICE_ACCOUNT_BASE64`, hoặc bộ `FIREBASE_PROJECT_ID` + `FIREBASE_CLIENT_EMAIL` + `FIREBASE_PRIVATE_KEY`; không cấu hình nhiều phương án cùng lúc.
 
-Tất cả Firebase Admin credential và biến `MAIL_*` là server-only: chỉ đặt trên Render, không sao chép sang Vercel, Git hoặc biến `NEXT_PUBLIC_*`. Gmail gửi mail cần bật 2-Step Verification rồi tạo App Password; không dùng mật khẩu Google thật. Firebase Authentication vẫn tự gửi email xác minh/reset mật khẩu miễn phí, còn Gmail SMTP chỉ gửi email mời xem chung. Không cần cài Firebase Trigger Email Extension (extension này yêu cầu billing).
+Tất cả Firebase Admin credential, `RESEND_*` và `MAIL_*` là server-only. Firebase Authentication vẫn tự gửi email xác minh/reset mật khẩu; Resend hoặc SMTP chỉ gửi email mời xem chung. Không cần cài Firebase Trigger Email Extension (extension này yêu cầu billing).
 
-Một lần mời luôn ghi notification trên web trước, sau đó mới thử Gmail. Vì vậy lỗi SMTP không xóa lời mời đã ghi. API trả riêng `inAppStatus`, `emailStatus` và `emailReason`; email chỉ gửi tới địa chỉ đã xác minh. Nếu mail chưa cấu hình, notification và chat vẫn hoạt động.
+Một lần mời luôn ghi notification trên web trước, sau đó mới thử nhà cung cấp email. Vì vậy lỗi Resend/SMTP không xóa lời mời đã ghi. API trả riêng `inAppStatus`, `emailStatus` và `emailReason`; email chỉ gửi tới địa chỉ đã xác minh. Nếu mail chưa cấu hình, notification và chat vẫn hoạt động.
 
 Vercel và `.env` local cần trỏ hai biến sau tới public Render URL, không có dấu `/` cuối:
 
@@ -77,7 +87,7 @@ Khi host bật voice, các thành viên online tự kết nối SFU với mic m�
 ## Operational endpoints
 
 - `GET /health`: process đang chạy.
-- `GET /ready`: Redis/store sẵn sàng nhận traffic và báo riêng `firebaseCredentialSource`, `firebaseAuthConfigured`, `firebaseAuthHealthy`, `socialDatabaseConfigured`, `socialDatabaseHealthy`, `mailConfigured`, `mailHealthy` và voice. Chỉ thử lookup email khi cả bốn trạng thái Firebase configured/healthy đều là `true`.
+- `GET /ready`: Redis/store sẵn sàng nhận traffic và báo riêng `firebaseCredentialSource`, `firebaseAuthConfigured`, `firebaseAuthHealthy`, `socialDatabaseConfigured`, `socialDatabaseHealthy`, `mailProvider`, `mailConfigured`, `mailHealthy` và voice. Với Resend, `mailHealthy` xác nhận client đã đủ cấu hình; lần gửi invite thực tế vẫn trả riêng trạng thái từ Resend.
 - `GET /api/rooms`: danh sách phòng public.
 - `POST /api/friends/lookup-email`: tìm chính xác tài khoản bằng email, yêu cầu Firebase Bearer token và giới hạn 10 lần/phút.
 - `POST /api/rooms/:roomId/invites`: tạo notification/email invite cho một người bạn, yêu cầu Firebase Bearer token.

--- a/socket-server/email-delivery.js
+++ b/socket-server/email-delivery.js
@@ -1,0 +1,107 @@
+import nodemailer from 'nodemailer'
+
+const RESEND_ENDPOINT = 'https://api.resend.com/emails'
+const DEFAULT_TIMEOUT_MS = 10_000
+
+export class EmailDeliveryError extends Error {
+  constructor(message, provider, status) {
+    super(message)
+    this.name = 'EmailDeliveryError'
+    this.provider = provider
+    this.status = status
+  }
+}
+
+export function resolveEmailDeliveryConfig(env = process.env) {
+  const resendApiKey = String(env.RESEND_API_KEY || '').trim()
+  const resendFrom = String(env.RESEND_FROM || '').trim()
+  const resendReplyTo = String(env.RESEND_REPLY_TO || '').trim()
+  const smtpUsername = String(env.MAIL_USERNAME || '').trim()
+  const smtpPassword = String(env.MAIL_PASSWORD || '').trim()
+  const smtpFrom = String(env.MAIL_FROM || smtpUsername).trim()
+
+  if (resendApiKey && resendFrom) {
+    return {
+      provider: 'resend',
+      resendApiKey,
+      from: resendFrom,
+      ...(resendReplyTo ? { replyTo: resendReplyTo } : {}),
+    }
+  }
+
+  if (smtpUsername && smtpPassword && smtpFrom) {
+    return {
+      provider: 'smtp',
+      from: `"${String(env.MAIL_FROM_NAME || 'CineMind').trim()}" <${smtpFrom}>`,
+      smtp: {
+        host: String(env.MAIL_HOST || 'smtp.gmail.com').trim(),
+        port: Number(env.MAIL_PORT || 587),
+        secure: String(env.MAIL_SECURE || 'false').toLowerCase() === 'true',
+        auth: { user: smtpUsername, pass: smtpPassword },
+        connectionTimeout: 5_000,
+        greetingTimeout: 5_000,
+        socketTimeout: 10_000,
+      },
+    }
+  }
+
+  return { provider: null }
+}
+
+export function createEmailDelivery(env = process.env, dependencies = {}) {
+  const config = resolveEmailDeliveryConfig(env)
+  const fetchImpl = dependencies.fetchImpl || globalThis.fetch
+  const createTransport = dependencies.createTransport || nodemailer.createTransport
+  const smtpTransporter = config.provider === 'smtp' ? createTransport(config.smtp) : null
+
+  return {
+    provider: config.provider,
+    configured: Boolean(config.provider),
+
+    async health() {
+      if (config.provider === 'resend') return true
+      if (!smtpTransporter) return false
+      return smtpTransporter.verify()
+    },
+
+    async send({ to, subject, text, html }) {
+      if (config.provider === 'resend') {
+        const controller = new AbortController()
+        const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS)
+        try {
+          const response = await fetchImpl(RESEND_ENDPOINT, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${config.resendApiKey}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              from: config.from,
+              to: [to],
+              subject,
+              text,
+              html,
+              ...(config.replyTo ? { reply_to: config.replyTo } : {}),
+            }),
+            signal: controller.signal,
+          })
+          if (!response.ok) {
+            const payload = await response.json().catch(() => ({}))
+            const detail = typeof payload?.message === 'string' ? payload.message : `HTTP ${response.status}`
+            throw new EmailDeliveryError(`Resend rejected the email: ${detail}`, 'resend', response.status)
+          }
+          return response.json().catch(() => ({}))
+        } catch (error) {
+          if (error instanceof EmailDeliveryError) throw error
+          const message = error?.name === 'AbortError' ? 'Resend request timed out' : 'Could not reach Resend'
+          throw new EmailDeliveryError(message, 'resend')
+        } finally {
+          clearTimeout(timer)
+        }
+      }
+
+      if (smtpTransporter) return smtpTransporter.sendMail({ from: config.from, to, subject, text, html })
+      throw new EmailDeliveryError('Email delivery is not configured', null)
+    },
+  }
+}

--- a/socket-server/email-delivery.test.js
+++ b/socket-server/email-delivery.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createEmailDelivery, EmailDeliveryError, resolveEmailDeliveryConfig } from './email-delivery.js'
+
+test('Resend is preferred over SMTP and reply-to remains optional', async () => {
+  let request
+  const delivery = createEmailDelivery({
+    RESEND_API_KEY: 're_test_key',
+    RESEND_FROM: 'CineMind <invite@namtechie.id.vn>',
+    MAIL_USERNAME: 'fallback@example.com',
+    MAIL_PASSWORD: 'fallback-password',
+  }, {
+    fetchImpl: async (url, options) => {
+      request = { url, options }
+      return { ok: true, status: 200, json: async () => ({ id: 'email_123' }) }
+    },
+    createTransport: () => { throw new Error('SMTP should not be created') },
+  })
+
+  assert.equal(delivery.provider, 'resend')
+  assert.equal(await delivery.health(), true)
+  await delivery.send({ to: 'friend@example.com', subject: 'Invite', text: 'Join us', html: '<p>Join us</p>' })
+
+  assert.equal(request.url, 'https://api.resend.com/emails')
+  assert.equal(request.options.headers.Authorization, 'Bearer re_test_key')
+  assert.deepEqual(JSON.parse(request.options.body), {
+    from: 'CineMind <invite@namtechie.id.vn>',
+    to: ['friend@example.com'],
+    subject: 'Invite',
+    text: 'Join us',
+    html: '<p>Join us</p>',
+  })
+})
+
+test('Resend includes reply-to only when configured', async () => {
+  let body
+  const delivery = createEmailDelivery({
+    RESEND_API_KEY: 're_test_key',
+    RESEND_FROM: 'CineMind <invite@namtechie.id.vn>',
+    RESEND_REPLY_TO: 'support@namtechie.id.vn',
+  }, {
+    fetchImpl: async (_url, options) => {
+      body = JSON.parse(options.body)
+      return { ok: true, status: 200, json: async () => ({ id: 'email_456' }) }
+    },
+  })
+
+  await delivery.send({ to: 'friend@example.com', subject: 'Invite', text: 'Join', html: '<p>Join</p>' })
+  assert.equal(body.reply_to, 'support@namtechie.id.vn')
+})
+
+test('Resend API errors are normalized without exposing credentials', async () => {
+  const delivery = createEmailDelivery({ RESEND_API_KEY: 'secret-value', RESEND_FROM: 'invite@namtechie.id.vn' }, {
+    fetchImpl: async () => ({ ok: false, status: 403, json: async () => ({ message: 'Domain is not verified' }) }),
+  })
+
+  await assert.rejects(
+    delivery.send({ to: 'friend@example.com', subject: 'Invite', text: 'Join', html: '<p>Join</p>' }),
+    (error) => error instanceof EmailDeliveryError
+      && error.provider === 'resend'
+      && error.status === 403
+      && !error.message.includes('secret-value'),
+  )
+})
+
+test('SMTP remains available as a fallback', () => {
+  assert.deepEqual(resolveEmailDeliveryConfig({
+    MAIL_USERNAME: 'sender@gmail.com',
+    MAIL_PASSWORD: 'app-password',
+    MAIL_FROM: 'sender@gmail.com',
+    MAIL_FROM_NAME: 'CineMind',
+  }), {
+    provider: 'smtp',
+    from: '"CineMind" <sender@gmail.com>',
+    smtp: {
+      host: 'smtp.gmail.com',
+      port: 587,
+      secure: false,
+      auth: { user: 'sender@gmail.com', pass: 'app-password' },
+      connectionTimeout: 5000,
+      greetingTimeout: 5000,
+      socketTimeout: 10000,
+    },
+  })
+})

--- a/socket-server/server.js
+++ b/socket-server/server.js
@@ -9,10 +9,10 @@ import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin
 import { getAuth } from 'firebase-admin/auth'
 import { getDatabase } from 'firebase-admin/database'
 import { AccessToken, RoomServiceClient } from 'livekit-server-sdk'
-import nodemailer from 'nodemailer'
 import { applyVoicePermission, attachDeviceSocket, buildVoiceGrant, chooseHostSuccessor, claimVacantHost, clearRoomHost, connectedMemberCount, createPairingRecord, detachDeviceSocket, findDeniedMediaEpisode, findEligibleInvitingMember, hashRoomPassword, isAllowedClientOrigin, isAllowedMediaUrl, isPairingUsable, isPublicRoomDiscoverable, markRoomEmpty, markRoomOccupied, normalizeRemoteCommand, remoteDeviceCount, REMOTE_PAIRING_TTL_MS, sanitizeScreenState, shouldCloseEmptyRoom, sourceCapability, verifyRoomPassword } from './watch-party-core.js'
 import { directoryProfile, isAnonymousFirebaseActor, requestIp } from './social-core.js'
 import { buildWatchPartyInviteEmail } from './email-templates.js'
+import { createEmailDelivery } from './email-delivery.js'
 import { firebaseAdminConfig } from './service-config.js'
 import dotenv from 'dotenv'
 
@@ -34,23 +34,9 @@ const LIVEKIT_URL = process.env.LIVEKIT_URL || ''
 const LIVEKIT_API_KEY = process.env.LIVEKIT_API_KEY || ''
 const LIVEKIT_API_SECRET = process.env.LIVEKIT_API_SECRET || ''
 const APP_BASE_URL = (process.env.APP_BASE_URL || CLIENT_ORIGINS[0] || 'http://localhost:3000').replace(/\/$/, '')
-const MAIL_HOST = process.env.MAIL_HOST || 'smtp.gmail.com'
-const MAIL_PORT = Number(process.env.MAIL_PORT || 587)
-const MAIL_SECURE = String(process.env.MAIL_SECURE || 'false').toLowerCase() === 'true'
-const MAIL_USERNAME = process.env.MAIL_USERNAME || ''
-const MAIL_PASSWORD = process.env.MAIL_PASSWORD || ''
-const MAIL_FROM = process.env.MAIL_FROM || MAIL_USERNAME
-const MAIL_FROM_NAME = process.env.MAIL_FROM_NAME || 'CineMind'
-const mailConfigured = Boolean(MAIL_USERNAME && MAIL_PASSWORD && MAIL_FROM)
-const mailTransporter = mailConfigured ? nodemailer.createTransport({
-  host: MAIL_HOST,
-  port: MAIL_PORT,
-  secure: MAIL_SECURE,
-  auth: { user: MAIL_USERNAME, pass: MAIL_PASSWORD },
-  connectionTimeout: 5_000,
-  greetingTimeout: 5_000,
-  socketTimeout: 10_000,
-}) : null
+const emailDelivery = createEmailDelivery(process.env)
+const mailConfigured = emailDelivery.configured
+const mailProvider = emailDelivery.provider
 const voiceConfigured = Boolean(LIVEKIT_URL && LIVEKIT_API_KEY && LIVEKIT_API_SECRET)
 const livekitRooms = voiceConfigured ? new RoomServiceClient(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) : null
 
@@ -131,12 +117,12 @@ const socialDatabaseHealth = async () => {
 let mailHealthCache = { value: false, expiresAt: 0 }
 let mailHealthInFlight = null
 const mailHealth = async () => {
-  if (!mailTransporter) return false
+  if (!mailConfigured) return false
   if (mailHealthCache.expiresAt > Date.now()) return mailHealthCache.value
   if (!mailHealthInFlight) {
     mailHealthInFlight = (async () => {
       try {
-        await mailTransporter.verify()
+        await emailDelivery.health()
         mailHealthCache = { value: true, expiresAt: Date.now() + 300_000 }
       } catch (error) {
         mailHealthCache = { value: false, expiresAt: Date.now() + 30_000 }
@@ -455,6 +441,7 @@ const server = http.createServer(async (req, res) => {
         store: redisClient ? 'redis' : 'memory',
         voiceConfigured,
         mailConfigured,
+        mailProvider,
         mailHealthy,
         firebaseCredentialSource,
         firebaseAuthConfigured: Boolean(adminAuth && adminCredential),
@@ -539,8 +526,8 @@ const server = http.createServer(async (req, res) => {
       }
       await adminDb.ref().update(updates)
       let emailStatus = 'skipped'
-      let emailReason = !mailTransporter ? 'not_configured' : targetSettings.emailNotifications === false ? 'disabled' : 'no_email'
-      if (mailTransporter && targetSettings.emailNotifications !== false) {
+      let emailReason = !mailConfigured ? 'not_configured' : targetSettings.emailNotifications === false ? 'disabled' : 'no_email'
+      if (mailConfigured && targetSettings.emailNotifications !== false) {
         try {
           const targetAccount = await adminAuth.getUser(friendUid)
           if (!targetAccount.email) emailReason = 'no_email'
@@ -554,7 +541,7 @@ const server = http.createServer(async (req, res) => {
               joinUrl,
               expiresAt: room.expiresAt,
             })
-            await mailTransporter.sendMail({ from: `"${MAIL_FROM_NAME}" <${MAIL_FROM}>`, to: targetAccount.email, ...email })
+            await emailDelivery.send({ to: targetAccount.email, ...email })
             emailStatus = 'sent'
             emailReason = undefined
           }
@@ -564,8 +551,8 @@ const server = http.createServer(async (req, res) => {
             emailReason = 'no_email'
           } else {
             emailStatus = 'failed'
-            emailReason = isFirebaseAdminFailure(error) ? 'firebase_admin' : 'smtp_error'
-            log('invite_email_failed', { roomId, inviteId, recipientUid: friendUid, reason: emailReason, error: error instanceof Error ? error.message : String(error) })
+            emailReason = isFirebaseAdminFailure(error) ? 'firebase_admin' : mailProvider === 'resend' ? 'email_api_error' : 'smtp_error'
+            log('invite_email_failed', { roomId, inviteId, recipientUid: friendUid, provider: mailProvider || undefined, reason: emailReason, error: error instanceof Error ? error.message : String(error) })
           }
         }
       }


### PR DESCRIPTION
## What changed

- prefer the Resend HTTPS API when `RESEND_API_KEY` and `RESEND_FROM` are configured
- keep SMTP as a fallback for local or hosts that permit SMTP ports
- keep `RESEND_REPLY_TO` optional and omit it from the API payload when unset
- expose `mailProvider` in `/ready` and return a provider-neutral email error to the UI
- stop the invite button from hanging indefinitely by aborting community API requests after 20 seconds
- document the Render Free + Resend setup and add isolated delivery tests

## Why

Render Free blocks outbound SMTP ports, so the Gmail App Password configuration times out even when the credentials are valid. Resend uses HTTPS and the verified `namtechie.id.vn` domain, while the in-app Firebase notification remains independent of email delivery.

## Verification

- `npm test` in `socket-server`: 27 passed
- `npx vitest run --reporter=verbose --maxWorkers=1 --no-file-parallelism`: 9 passed
- `npm run build`: passed
- `git diff --cached --check`: passed before commit

## Deployment check

After merging and Render redeploys, `/ready` should report `mailProvider: "resend"`, `mailConfigured: true`, and `mailHealthy: true`. Then send one watch-party invite to a Firebase account with a verified email and confirm both the web notification and email arrive.
